### PR TITLE
Reset cached data when user sessions change

### DIFF
--- a/nutriz-backend/controllers/mealController.js
+++ b/nutriz-backend/controllers/mealController.js
@@ -1,0 +1,220 @@
+const asyncHandler = require('express-async-handler');
+const Meal = require('../models/Meal');
+const FoodItem = require('../models/FoodItem');
+
+const toNumber = (value, fallback = 0) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+};
+
+const normaliseAmount = (value) => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 1;
+  if (num < 0) return 0;
+  return num;
+};
+
+const normaliseMacros = (macros = {}) => ({
+  calories: toNumber(macros.calories),
+  protein: toNumber(macros.protein),
+  carbs: toNumber(macros.carbs),
+  fat: toNumber(macros.fat),
+});
+
+const sumMacros = (components = []) =>
+  components.reduce(
+    (acc, component) => {
+      acc.calories += component.macros?.calories || 0;
+      acc.protein += component.macros?.protein || 0;
+      acc.carbs += component.macros?.carbs || 0;
+      acc.fat += component.macros?.fat || 0;
+      return acc;
+    },
+    { calories: 0, protein: 0, carbs: 0, fat: 0 }
+  );
+
+const buildComponentPayload = async (component = {}, userId) => {
+  const type = component.type || (component.foodId ? 'food' : 'custom');
+  const amount = normaliseAmount(component.amount);
+  const notes = component.notes || '';
+
+  if (type === 'food') {
+    const foodId = component.foodId || component.foodItem || component.sourceId;
+    if (!foodId) {
+      throw new Error('Food component requires a foodId');
+    }
+
+    const foodItem = await FoodItem.findOne({
+      _id: foodId,
+      nutritionist: userId,
+    });
+
+    if (!foodItem) {
+      throw new Error(`Food item with ID ${foodId} not found`);
+    }
+
+    const macrosSource = component.macrosSource === 'overridden' ? 'overridden' : 'auto';
+    const macros =
+      macrosSource === 'overridden'
+        ? normaliseMacros(component.macros)
+        : {
+            calories: (foodItem.caloriesPerServing || 0) * amount,
+            protein: (foodItem.proteinPerServing || 0) * amount,
+            carbs: (foodItem.carbsPerServing || 0) * amount,
+            fat: (foodItem.fatPerServing || 0) * amount,
+          };
+
+    return {
+      type: 'food',
+      foodItem: foodItem._id,
+      amount,
+      notes,
+      macros,
+      macrosSource,
+    };
+  }
+
+  return {
+    type: 'custom',
+    customName: component.customName || '',
+    serving: component.serving || '',
+    amount,
+    notes,
+    macros: normaliseMacros(component.macros),
+    macrosSource: 'overridden',
+  };
+};
+
+const populateMeal = async (meal) =>
+  meal.populate({
+    path: 'components.foodItem',
+    select:
+      'name defaultServingSize caloriesPerServing proteinPerServing carbsPerServing fatPerServing',
+  });
+
+// @desc    Get all meals for the authenticated nutritionist
+// @route   GET /api/meals
+// @access  Private/Nutritionist
+const getMeals = asyncHandler(async (req, res) => {
+  const meals = await Meal.find({ nutritionist: req.user.id })
+    .sort({ createdAt: -1 })
+    .populate({
+      path: 'components.foodItem',
+      select:
+        'name defaultServingSize caloriesPerServing proteinPerServing carbsPerServing fatPerServing',
+    });
+
+  res.status(200).json(meals);
+});
+
+// @desc    Create a new meal template
+// @route   POST /api/meals
+// @access  Private/Nutritionist
+const createMeal = asyncHandler(async (req, res) => {
+  const { name, description = '', components = [], macrosSource } = req.body;
+
+  if (!name) {
+    res.status(400);
+    throw new Error('Meal name is required');
+  }
+
+  const mappedComponents = [];
+  for (const component of components) {
+    try {
+      const payload = await buildComponentPayload(component, req.user.id);
+      mappedComponents.push(payload);
+    } catch (error) {
+      const notFound = /not found/i.test(error.message || "");
+      res.status(notFound ? 404 : 400);
+      throw new Error(error.message);
+    }
+  }
+
+  const totals = sumMacros(mappedComponents);
+
+  const meal = await Meal.create({
+    nutritionist: req.user.id,
+    name,
+    description,
+    components: mappedComponents,
+    macros: totals,
+    macrosSource: macrosSource === 'overridden' ? 'overridden' : 'auto',
+  });
+
+  await populateMeal(meal);
+
+  res.status(201).json(meal);
+});
+
+// @desc    Update an existing meal template
+// @route   PUT /api/meals/:id
+// @access  Private/Nutritionist
+const updateMeal = asyncHandler(async (req, res) => {
+  const meal = await Meal.findOne({
+    _id: req.params.id,
+    nutritionist: req.user.id,
+  });
+
+  if (!meal) {
+    res.status(404);
+    throw new Error('Meal not found');
+  }
+
+  const { name, description = '', components = [], macrosSource } = req.body;
+
+  if (!name) {
+    res.status(400);
+    throw new Error('Meal name is required');
+  }
+
+  const mappedComponents = [];
+  for (const component of components) {
+    try {
+      const payload = await buildComponentPayload(component, req.user.id);
+      mappedComponents.push(payload);
+    } catch (error) {
+      const notFound = /not found/i.test(error.message || "");
+      res.status(notFound ? 404 : 400);
+      throw new Error(error.message);
+    }
+  }
+
+  const totals = sumMacros(mappedComponents);
+
+  meal.name = name;
+  meal.description = description;
+  meal.components = mappedComponents;
+  meal.macros = totals;
+  meal.macrosSource = macrosSource === 'overridden' ? 'overridden' : 'auto';
+
+  await meal.save();
+  await populateMeal(meal);
+
+  res.status(200).json(meal);
+});
+
+// @desc    Delete a meal template
+// @route   DELETE /api/meals/:id
+// @access  Private/Nutritionist
+const deleteMeal = asyncHandler(async (req, res) => {
+  const meal = await Meal.findOne({
+    _id: req.params.id,
+    nutritionist: req.user.id,
+  });
+
+  if (!meal) {
+    res.status(404);
+    throw new Error('Meal not found');
+  }
+
+  await meal.deleteOne();
+
+  res.status(200).json({ message: 'Meal removed' });
+});
+
+module.exports = {
+  getMeals,
+  createMeal,
+  updateMeal,
+  deleteMeal,
+};

--- a/nutriz-backend/controllers/programController.js
+++ b/nutriz-backend/controllers/programController.js
@@ -1,0 +1,189 @@
+const asyncHandler = require('express-async-handler');
+const mongoose = require('mongoose');
+const Program = require('../models/Program');
+const Client = require('../models/Client');
+
+const toNumber = (value, fallback = 0) => {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+};
+
+const normaliseMacros = (macros = {}) => ({
+  calories: toNumber(macros.calories),
+  protein: toNumber(macros.protein),
+  carbs: toNumber(macros.carbs),
+  fat: toNumber(macros.fat),
+});
+
+const normaliseItem = (item = {}) => ({
+  id: item.id || new mongoose.Types.ObjectId().toString(),
+  type: item.type || (item.sourceId ? 'food' : 'custom'),
+  sourceId:
+    item.sourceId !== undefined && item.sourceId !== null
+      ? String(item.sourceId)
+      : null,
+  name: item.name || '',
+  amount: Math.max(0, toNumber(item.amount, 1)),
+  unit: item.unit || '',
+  notes: item.notes || '',
+  time: item.time || '',
+  macros: normaliseMacros(item.macros),
+  macrosSource: item.macrosSource === 'overridden' ? 'overridden' : 'auto',
+});
+
+const normaliseMeal = (meal = {}) => ({
+  id: meal.id || new mongoose.Types.ObjectId().toString(),
+  name: meal.name || meal.mealTime || 'Meal',
+  mealTime: meal.mealTime || meal.name || 'Meal',
+  time: meal.time || '',
+  items: Array.isArray(meal.items) ? meal.items.map(normaliseItem) : [],
+  macros: normaliseMacros(meal.macros),
+  macrosSource: meal.macrosSource === 'overridden' ? 'overridden' : 'auto',
+});
+
+const normaliseDay = (day = {}) => ({
+  date: day.date || '',
+  meals: Array.isArray(day.meals) ? day.meals.map(normaliseMeal) : [],
+  macros: normaliseMacros(day.macros),
+  macrosSource: day.macrosSource === 'overridden' ? 'overridden' : 'auto',
+});
+
+const buildProgramPayload = (body = {}) => {
+  const startDate = body.startDate || (body.days?.[0]?.date ?? '');
+  const days = Array.isArray(body.days) ? body.days.map(normaliseDay) : [];
+  return {
+    name: body.name || '',
+    client: body.clientId,
+    startDate,
+    length: toNumber(body.length, days.length || 0),
+    macros: normaliseMacros(body.macros),
+    macrosSource: body.macrosSource === 'overridden' ? 'overridden' : 'auto',
+    days,
+  };
+};
+
+// @desc    Get all programs for the authenticated nutritionist
+// @route   GET /api/programs
+// @access  Private/Nutritionist
+const getPrograms = asyncHandler(async (req, res) => {
+  const filter = { nutritionist: req.user.id };
+  if (req.query.clientId) {
+    filter.client = req.query.clientId;
+  }
+  const programs = await Program.find(filter).sort({ createdAt: -1 });
+  res.status(200).json(programs);
+});
+
+// @desc    Get program by ID
+// @route   GET /api/programs/:id
+// @access  Private/Nutritionist
+const getProgramById = asyncHandler(async (req, res) => {
+  const program = await Program.findOne({
+    _id: req.params.id,
+    nutritionist: req.user.id,
+  });
+
+  if (!program) {
+    res.status(404);
+    throw new Error('Program not found');
+  }
+
+  res.status(200).json(program);
+});
+
+// @desc    Create a program for a client
+// @route   POST /api/programs
+// @access  Private/Nutritionist
+const createProgram = asyncHandler(async (req, res) => {
+  const { clientId } = req.body;
+  if (!clientId) {
+    res.status(400);
+    throw new Error('Client ID is required');
+  }
+
+  const client = await Client.findOne({
+    _id: clientId,
+    nutritionist: req.user.id,
+  });
+
+  if (!client) {
+    res.status(404);
+    throw new Error('Client not found');
+  }
+
+  const payload = buildProgramPayload(req.body);
+  payload.nutritionist = req.user.id;
+  payload.client = clientId;
+  payload.length = payload.length || payload.days.length || 0;
+
+  const program = await Program.create(payload);
+  res.status(201).json(program);
+});
+
+// @desc    Update a program
+// @route   PUT /api/programs/:id
+// @access  Private/Nutritionist
+const updateProgram = asyncHandler(async (req, res) => {
+  const program = await Program.findOne({
+    _id: req.params.id,
+    nutritionist: req.user.id,
+  });
+
+  if (!program) {
+    res.status(404);
+    throw new Error('Program not found');
+  }
+
+  if (req.body.clientId && String(req.body.clientId) !== String(program.client)) {
+    const client = await Client.findOne({
+      _id: req.body.clientId,
+      nutritionist: req.user.id,
+    });
+
+    if (!client) {
+      res.status(404);
+      throw new Error('Client not found');
+    }
+
+    program.client = client._id;
+  }
+
+  const payload = buildProgramPayload({ ...req.body, clientId: program.client });
+
+  program.name = payload.name;
+  program.startDate = payload.startDate;
+  program.length = payload.length || payload.days.length || 0;
+  program.macros = payload.macros;
+  program.macrosSource = payload.macrosSource;
+  program.days = payload.days;
+
+  await program.save();
+
+  res.status(200).json(program);
+});
+
+// @desc    Delete a program
+// @route   DELETE /api/programs/:id
+// @access  Private/Nutritionist
+const deleteProgram = asyncHandler(async (req, res) => {
+  const program = await Program.findOne({
+    _id: req.params.id,
+    nutritionist: req.user.id,
+  });
+
+  if (!program) {
+    res.status(404);
+    throw new Error('Program not found');
+  }
+
+  await program.deleteOne();
+  res.status(200).json({ message: 'Program removed' });
+});
+
+module.exports = {
+  getPrograms,
+  getProgramById,
+  createProgram,
+  updateProgram,
+  deleteProgram,
+};

--- a/nutriz-backend/models/Meal.js
+++ b/nutriz-backend/models/Meal.js
@@ -1,0 +1,71 @@
+const mongoose = require('mongoose');
+
+const macroTotalsSchema = new mongoose.Schema(
+  {
+    calories: { type: Number, default: 0 },
+    protein: { type: Number, default: 0 },
+    carbs: { type: Number, default: 0 },
+    fat: { type: Number, default: 0 },
+  },
+  { _id: false }
+);
+
+const mealComponentSchema = new mongoose.Schema(
+  {
+    type: {
+      type: String,
+      enum: ['food', 'custom'],
+      default: 'food',
+    },
+    foodItem: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'FoodItem',
+    },
+    customName: { type: String, default: '' },
+    serving: { type: String, default: '' },
+    amount: { type: Number, default: 1 },
+    notes: { type: String, default: '' },
+    macros: { type: macroTotalsSchema, default: () => ({}) },
+    macrosSource: {
+      type: String,
+      enum: ['auto', 'overridden'],
+      default: 'auto',
+    },
+  },
+  { timestamps: false }
+);
+
+const mealSchema = new mongoose.Schema(
+  {
+    nutritionist: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    description: {
+      type: String,
+      default: '',
+    },
+    components: {
+      type: [mealComponentSchema],
+      default: [],
+    },
+    macros: {
+      type: macroTotalsSchema,
+      default: () => ({})
+    },
+    macrosSource: {
+      type: String,
+      enum: ['auto', 'overridden'],
+      default: 'auto',
+    },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Meal', mealSchema);

--- a/nutriz-backend/models/Program.js
+++ b/nutriz-backend/models/Program.js
@@ -1,0 +1,94 @@
+const mongoose = require('mongoose');
+
+const MacroSchema = new mongoose.Schema(
+  {
+    calories: { type: Number, default: 0 },
+    protein: { type: Number, default: 0 },
+    carbs: { type: Number, default: 0 },
+    fat: { type: Number, default: 0 },
+  },
+  { _id: false }
+);
+
+const ProgramItemSchema = new mongoose.Schema(
+  {
+    id: { type: String, required: true },
+    type: {
+      type: String,
+      enum: ['food', 'meal', 'recipe', 'custom'],
+      default: 'custom',
+    },
+    sourceId: { type: String, default: null },
+    name: { type: String, default: '' },
+    amount: { type: Number, default: 1 },
+    unit: { type: String, default: '' },
+    notes: { type: String, default: '' },
+    time: { type: String, default: '' },
+    macros: { type: MacroSchema, default: () => ({}) },
+    macrosSource: {
+      type: String,
+      enum: ['auto', 'overridden'],
+      default: 'auto',
+    },
+  },
+  { _id: false }
+);
+
+const ProgramMealSchema = new mongoose.Schema(
+  {
+    id: { type: String, required: true },
+    name: { type: String, default: '' },
+    mealTime: { type: String, default: '' },
+    time: { type: String, default: '' },
+    items: { type: [ProgramItemSchema], default: () => [] },
+    macros: { type: MacroSchema, default: () => ({}) },
+    macrosSource: {
+      type: String,
+      enum: ['auto', 'overridden'],
+      default: 'auto',
+    },
+  },
+  { _id: false }
+);
+
+const ProgramDaySchema = new mongoose.Schema(
+  {
+    date: { type: String, required: true },
+    meals: { type: [ProgramMealSchema], default: () => [] },
+    macros: { type: MacroSchema, default: () => ({}) },
+    macrosSource: {
+      type: String,
+      enum: ['auto', 'overridden'],
+      default: 'auto',
+    },
+  },
+  { _id: false }
+);
+
+const ProgramSchema = new mongoose.Schema(
+  {
+    nutritionist: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    client: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Client',
+      required: true,
+    },
+    name: { type: String, default: '' },
+    startDate: { type: String, default: '' },
+    length: { type: Number, default: 0 },
+    macros: { type: MacroSchema, default: () => ({}) },
+    macrosSource: {
+      type: String,
+      enum: ['auto', 'overridden'],
+      default: 'auto',
+    },
+    days: { type: [ProgramDaySchema], default: () => [] },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Program', ProgramSchema);

--- a/nutriz-backend/routes/mealRoutes.js
+++ b/nutriz-backend/routes/mealRoutes.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const {
+  getMeals,
+  createMeal,
+  updateMeal,
+  deleteMeal,
+} = require('../controllers/mealController');
+const { protect, authorizeRoles } = require('../middleware/authMiddleware');
+
+const router = express.Router();
+
+router
+  .route('/')
+  .get(protect, authorizeRoles('nutritionist', 'admin'), getMeals)
+  .post(protect, authorizeRoles('nutritionist', 'admin'), createMeal);
+
+router
+  .route('/:id')
+  .put(protect, authorizeRoles('nutritionist', 'admin'), updateMeal)
+  .delete(protect, authorizeRoles('nutritionist', 'admin'), deleteMeal);
+
+module.exports = router;

--- a/nutriz-backend/routes/programRoutes.js
+++ b/nutriz-backend/routes/programRoutes.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const {
+  getPrograms,
+  getProgramById,
+  createProgram,
+  updateProgram,
+  deleteProgram,
+} = require('../controllers/programController');
+const { protect } = require('../middleware/authMiddleware');
+
+const router = express.Router();
+
+router.use(protect);
+
+router.route('/').get(getPrograms).post(createProgram);
+router.route('/:id').get(getProgramById).put(updateProgram).delete(deleteProgram);
+
+module.exports = router;

--- a/nutriz-backend/server.js
+++ b/nutriz-backend/server.js
@@ -7,6 +7,8 @@ const authRoutes = require('./routes/authRoutes');
 const foodItemRoutes = require('./routes/foodItemRoutes'); // Import food item routes
 const clientRoutes = require('./routes/clientRoutes');     // Import client routes
 const recipeRoutes = require('./routes/recipeRoutes');     // Import recipe routes
+const mealRoutes = require('./routes/mealRoutes');         // Import meal routes
+const programRoutes = require('./routes/programRoutes');   // Import program routes
 const { errorHandler } = require('./middleware/errorMiddleware');
 
 // Load env vars
@@ -64,6 +66,8 @@ app.use('/api/auth', authRoutes);
 app.use('/api/fooditems', foodItemRoutes); // Food Item routes
 app.use('/api/clients', clientRoutes);     // Client routes
 app.use('/api/recipes', recipeRoutes);     // Recipe routes
+app.use('/api/meals', mealRoutes);         // Meal routes
+app.use('/api/programs', programRoutes);   // Program routes
 
 // Basic route
 app.get('/', (req, res) => {

--- a/src/stores/authStore.js
+++ b/src/stores/authStore.js
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import api, { setAuthToken } from '@/services/api';
+import { useDataStore } from './useDataStore';
 
 const TOKEN_KEY = 'nutriz_token';
 
@@ -17,6 +18,14 @@ export const useAuthStore = defineStore('auth', () => {
   const isAuthenticated = computed(() => Boolean(token.value));
 
   const setSession = (payload) => {
+    const previousUserId = user.value?.id ? String(user.value.id) : null;
+    const nextUserId = payload?._id ? String(payload._id) : null;
+
+    if (!payload || previousUserId !== nextUserId) {
+      const dataStore = useDataStore();
+      dataStore.resetAll();
+    }
+
     token.value = payload?.token || '';
     user.value = payload
       ? {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -197,6 +197,7 @@ onMounted(async () => {
     await Promise.all([
       dataStore.fetchClients(),
       dataStore.fetchFoods(),
+      dataStore.fetchMeals(),
       dataStore.fetchRecipes(),
     ]);
   } catch (error) {

--- a/src/views/MealsView.vue
+++ b/src/views/MealsView.vue
@@ -5,13 +5,35 @@
         <h1 class="text-h4">Meals Database</h1>
       </v-col>
       <v-col class="text-right">
-        <v-btn color="primary" prepend-icon="mdi-plus" @click="openAddDialog">Add Meal</v-btn>
+        <v-btn
+          color="primary"
+          prepend-icon="mdi-plus"
+          @click="openAddDialog"
+          :loading="isLoadingMeals || isSubmitting"
+        >
+          Add Meal
+        </v-btn>
       </v-col>
     </v-row>
 
+    <v-alert
+      v-if="lastError"
+      type="error"
+      class="mb-4"
+      border="start"
+      variant="tonal"
+      :text="lastError"
+    />
+
     <v-card>
       <v-card-text>
-        <v-data-table :headers="headers" :items="mealsWithMacros" item-key="id">
+        <v-data-table
+          :headers="headers"
+          :items="mealsWithMacros"
+          item-key="id"
+          :loading="isLoadingMeals"
+          loading-text="Loading meals..."
+        >
           <template v-slot:item.macros="{ item }">
             Cal: {{ item.totalMacros.calories.toFixed(0) }} / Prot: {{ item.totalMacros.protein.toFixed(0) }}g / Carb: {{ item.totalMacros.carbs.toFixed(0) }}g / Fat: {{ item.totalMacros.fat.toFixed(0) }}g
           </template>
@@ -45,7 +67,7 @@
                   <v-row align="center" dense>
                     <v-col cols="12" sm="6">
                       <v-autocomplete
-                        v-if="!('customName' in component)"
+                        v-if="component.type === 'food'"
                         :model-value="component.foodId"
                         @update:model-value="updateComponent(index, $event)"
                         :items="foods"
@@ -64,11 +86,18 @@
                       ></v-text-field>
                     </v-col>
                     <v-col cols="4" sm="2">
-                       <v-text-field v-model.number="component.amount" label="Amount" type="number" density="compact" hide-details @update:model-value="recalculateMacros(component, true)"></v-text-field>
+                       <v-text-field
+                         v-model.number="component.amount"
+                         label="Amount"
+                         type="number"
+                         density="compact"
+                         hide-details
+                         @update:model-value="() => handleAmountChange(component)"
+                       ></v-text-field>
                     </v-col>
                     <v-col cols="4" sm="2">
                        <v-text-field
-                          v-if="'customName' in component"
+                          v-if="component.type === 'custom'"
                           v-model="component.serving"
                           label="Serving"
                           placeholder="e.g. cup"
@@ -96,10 +125,45 @@
                       <v-divider class="my-3"></v-divider>
                       <p class="text-caption">Override Macros for this Component</p>
                       <v-row dense>
-                        <v-col><v-text-field v-model.number="component.macros.calories" label="Calories" density="compact" type="number"></v-text-field></v-col>
-                        <v-col><v-text-field v-model.number="component.macros.protein" label="Protein" density="compact" type="number" suffix="g"></v-text-field></v-col>
-                        <v-col><v-text-field v-model.number="component.macros.carbs" label="Carbs" density="compact" type="number" suffix="g"></v-text-field></v-col>
-                        <v-col><v-text-field v-model.number="component.macros.fat" label="Fat" density="compact" type="number" suffix="g"></v-text-field></v-col>
+                        <v-col>
+                          <v-text-field
+                            v-model.number="component.macros.calories"
+                            label="Calories"
+                            density="compact"
+                            type="number"
+                            @update:model-value="() => markManual(component)"
+                          ></v-text-field>
+                        </v-col>
+                        <v-col>
+                          <v-text-field
+                            v-model.number="component.macros.protein"
+                            label="Protein"
+                            density="compact"
+                            type="number"
+                            suffix="g"
+                            @update:model-value="() => markManual(component)"
+                          ></v-text-field>
+                        </v-col>
+                        <v-col>
+                          <v-text-field
+                            v-model.number="component.macros.carbs"
+                            label="Carbs"
+                            density="compact"
+                            type="number"
+                            suffix="g"
+                            @update:model-value="() => markManual(component)"
+                          ></v-text-field>
+                        </v-col>
+                        <v-col>
+                          <v-text-field
+                            v-model.number="component.macros.fat"
+                            label="Fat"
+                            density="compact"
+                            type="number"
+                            suffix="g"
+                            @update:model-value="() => markManual(component)"
+                          ></v-text-field>
+                        </v-col>
                       </v-row>
                     </div>
                   </v-expand-transition>
@@ -113,8 +177,16 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="blue-darken-1" variant="text" @click="closeDialog">Cancel</v-btn>
-          <v-btn color="blue-darken-1" variant="text" @click="saveMeal">Save</v-btn>
+          <v-btn color="blue-darken-1" variant="text" @click="closeDialog" :disabled="isSubmitting">Cancel</v-btn>
+          <v-btn
+            color="blue-darken-1"
+            variant="text"
+            @click="saveMeal"
+            :loading="isSubmitting"
+            :disabled="isSubmitting"
+          >
+            Save
+          </v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -122,40 +194,92 @@
 </template>
 
 <script setup>
-import { ref, computed } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { useDataStore } from "@/stores/useDataStore";
 import { storeToRefs } from "pinia";
 
 const dataStore = useDataStore();
-const { meals, foods } = storeToRefs(dataStore);
+const { meals, foods, isLoadingMeals, lastError } = storeToRefs(dataStore);
 
 const dialog = ref(false);
 const form = ref(null);
 const editedIndex = ref(-1);
+const isSubmitting = ref(false);
 
-const defaultItem = { id: null, name: "", components: [] };
+const defaultItem = { id: null, name: "", description: "", components: [], macrosSource: "auto" };
 const editedItem = ref(JSON.parse(JSON.stringify(defaultItem)));
 
 const formTitle = computed(() => (editedIndex.value === -1 ? "Add New Meal" : "Edit Meal"));
 const rules = { required: (value) => !!value || "Required." };
 
-// --- HELPER FUNCTION ---
+onMounted(async () => {
+  try {
+    if (!foods.value.length) {
+      await dataStore.fetchFoods().catch(() => {});
+    }
+    await dataStore.fetchMeals().catch(() => {});
+  } catch (error) {
+    // Errors are surfaced via lastError from the store
+  }
+});
+
+function ensureComponentMeta(component) {
+  if (!component) return;
+  component.type = component.type || (component.customName != null ? "custom" : "food");
+  if (!component.macros) {
+    component.macros = { calories: 0, protein: 0, carbs: 0, fat: 0 };
+  }
+  if (!component.macrosSource) {
+    component.macrosSource = component.type === "custom" ? "overridden" : "auto";
+  }
+  if (component.expanded === undefined) {
+    component.expanded = component.type === "custom";
+  }
+}
+
+function createComponent(type) {
+  if (type === "custom") {
+    return {
+      type: "custom",
+      customName: "",
+      serving: "",
+      amount: 1,
+      notes: "",
+      macros: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+      macrosSource: "overridden",
+      expanded: true,
+    };
+  }
+
+  return {
+    type: "food",
+    foodId: null,
+    amount: 1,
+    notes: "",
+    macros: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+    macrosSource: "auto",
+    expanded: false,
+  };
+}
+
 function getMacros(component, forceRecalc = false) {
   const emptyMacros = { calories: 0, protein: 0, carbs: 0, fat: 0 };
   if (!component) return emptyMacros;
 
-  if (component.expanded && !forceRecalc) {
-      return component.macros || emptyMacros;
-  }
-  
-  if ('customName' in component) {
-      return component.macros || emptyMacros;
+  ensureComponentMeta(component);
+
+  if (component.macrosSource === "overridden" && !forceRecalc) {
+    return component.macros || emptyMacros;
   }
 
-  const food = foods.value.find(f => f.id === component.foodId);
+  if (component.type === "custom") {
+    return component.macros || emptyMacros;
+  }
+
+  const food = foods.value.find((f) => f.id === component.foodId);
   if (!food) return emptyMacros;
-  
-  const multiplier = component.amount || 0;
+
+  const multiplier = Number(component.amount) || 0;
   return {
     calories: (food.macrosPerServing.calories || 0) * multiplier,
     protein: (food.macrosPerServing.protein || 0) * multiplier,
@@ -164,31 +288,44 @@ function getMacros(component, forceRecalc = false) {
   };
 }
 
-// --- COMPUTED PROPERTIES ---
 const mealsWithMacros = computed(() => {
-  return meals.value.map(meal => {
-    const totalMacros = (meal.components || []).reduce((totals, component) => {
-      const macros = getMacros(component, true); // Always force recalc for the list view
-      totals.calories += macros.calories;
-      totals.protein += macros.protein;
-      totals.carbs += macros.carbs;
-      totals.fat += macros.fat;
-      return totals;
-    }, { calories: 0, protein: 0, carbs: 0, fat: 0 });
-    return { ...meal, totalMacros };
+  return meals.value.map((meal) => {
+    const totals = meal.macros
+      ? {
+          calories: Number(meal.macros.calories) || 0,
+          protein: Number(meal.macros.protein) || 0,
+          carbs: Number(meal.macros.carbs) || 0,
+          fat: Number(meal.macros.fat) || 0,
+        }
+      : (meal.components || []).reduce(
+          (acc, component) => {
+            const macros = getMacros(component, component.macrosSource !== "overridden");
+            acc.calories += Number(macros.calories) || 0;
+            acc.protein += Number(macros.protein) || 0;
+            acc.carbs += Number(macros.carbs) || 0;
+            acc.fat += Number(macros.fat) || 0;
+            return acc;
+          },
+          { calories: 0, protein: 0, carbs: 0, fat: 0 }
+        );
+
+    return { ...meal, totalMacros: totals };
   });
 });
 
 const mealTotalMacros = computed(() => {
   if (!editedItem.value.components) return { calories: 0, protein: 0, carbs: 0, fat: 0 };
-  return editedItem.value.components.reduce((totals, component) => {
-    const macros = getMacros(component);
-    totals.calories += Number(macros.calories) || 0;
-    totals.protein += Number(macros.protein) || 0;
-    totals.carbs += Number(macros.carbs) || 0;
-    totals.fat += Number(macros.fat) || 0;
-    return totals;
-  }, { calories: 0, protein: 0, carbs: 0, fat: 0 });
+  return editedItem.value.components.reduce(
+    (totals, component) => {
+      const macros = getMacros(component);
+      totals.calories += Number(macros.calories) || 0;
+      totals.protein += Number(macros.protein) || 0;
+      totals.carbs += Number(macros.carbs) || 0;
+      totals.fat += Number(macros.fat) || 0;
+      return totals;
+    },
+    { calories: 0, protein: 0, carbs: 0, fat: 0 }
+  );
 });
 
 const headers = ref([
@@ -197,17 +334,11 @@ const headers = ref([
   { title: "Actions", key: "actions", sortable: false },
 ]);
 
-// --- COMPONENT LOGIC ---
 function addComponent(type) {
-  const newComponent = { amount: 1, macros: { calories: 0, protein: 0, carbs: 0, fat: 0 }, expanded: false };
-  if (type === 'food') {
-    newComponent.foodId = null;
-  } else if (type === 'custom') {
-    newComponent.customName = "";
-    newComponent.serving = "";
-    newComponent.expanded = true; // Custom items start expanded to enter macros
+  if (!editedItem.value.components) {
+    editedItem.value.components = [];
   }
-  editedItem.value.components.push(newComponent);
+  editedItem.value.components.push(createComponent(type));
 }
 
 function removeComponent(index) {
@@ -215,39 +346,72 @@ function removeComponent(index) {
 }
 
 function getServing(component) {
-  if ('customName' in component) return component.serving || "unit";
-  const food = foods.value.find(f => f.id === component.foodId);
+  if (!component || component.type === "custom") return component?.serving || "unit";
+  const food = foods.value.find((f) => f.id === component.foodId);
   return food ? food.servingUnit : "";
 }
 
 function updateComponent(index, foodId) {
   const component = editedItem.value.components[index];
-  component.foodId = foodId;
-  recalculateMacros(component, true); // Force recalculation
+  if (!component) return;
+  component.type = "food";
+  component.foodId = foodId || null;
+  component.macrosSource = "auto";
+  recalculateMacros(component, true);
+}
+
+function markManual(component) {
+  if (!component) return;
+  ensureComponentMeta(component);
+  component.macrosSource = "overridden";
+}
+
+function handleAmountChange(component) {
+  if (!component) return;
+  if (component.type === "food") {
+    component.macrosSource = "auto";
+    recalculateMacros(component, true);
+  } else {
+    markManual(component);
+  }
 }
 
 function recalculateMacros(component, force = false) {
-    if (component.expanded && !force) return; // Respect manual overrides unless forced
-    component.macros = getMacros(component, true);
+  if (!component) return;
+  if (component.macrosSource === "overridden" && !force) return;
+  const macros = getMacros(component, true);
+  component.macros = {
+    calories: Number(macros.calories) || 0,
+    protein: Number(macros.protein) || 0,
+    carbs: Number(macros.carbs) || 0,
+    fat: Number(macros.fat) || 0,
+  };
+  component.macrosSource = "auto";
 }
 
 function openAddDialog() {
   editedIndex.value = -1;
   editedItem.value = JSON.parse(JSON.stringify(defaultItem));
-  editedItem.value.id = Date.now();
   dialog.value = true;
 }
 
 function editMeal(item) {
-  editedIndex.value = meals.value.findIndex(m => m.id === item.id);
-  // Find the original item from the base `meals` ref to edit
+  editedIndex.value = meals.value.findIndex((m) => m.id === item.id);
   const originalMeal = meals.value[editedIndex.value];
   const mealToEdit = JSON.parse(JSON.stringify(originalMeal));
-  // Initialize UI state properties
-  (mealToEdit.components || []).forEach(c => {
-      c.expanded = false;
-      // Pre-calculate macros for editing
-      c.macros = getMacros(c, true);
+  (mealToEdit.components || []).forEach((component) => {
+    ensureComponentMeta(component);
+    component.expanded = false;
+    if (component.macrosSource !== "overridden") {
+      recalculateMacros(component, true);
+    } else {
+      component.macros = {
+        calories: Number(component.macros?.calories) || 0,
+        protein: Number(component.macros?.protein) || 0,
+        carbs: Number(component.macros?.carbs) || 0,
+        fat: Number(component.macros?.fat) || 0,
+      };
+    }
   });
   editedItem.value = mealToEdit;
   dialog.value = true;
@@ -255,28 +419,55 @@ function editMeal(item) {
 
 function closeDialog() {
   dialog.value = false;
+  isSubmitting.value = false;
+  editedItem.value = JSON.parse(JSON.stringify(defaultItem));
+  editedIndex.value = -1;
+}
+
+function prepareMealForSave(meal) {
+  const clone = JSON.parse(JSON.stringify(meal));
+  clone.components = (clone.components || []).map((component) => {
+    ensureComponentMeta(component);
+    component.macros = {
+      calories: Number(component.macros?.calories) || 0,
+      protein: Number(component.macros?.protein) || 0,
+      carbs: Number(component.macros?.carbs) || 0,
+      fat: Number(component.macros?.fat) || 0,
+    };
+    delete component.expanded;
+    return component;
+  });
+  return clone;
 }
 
 async function saveMeal() {
+  if (!form.value) return;
   const { valid } = await form.value.validate();
   if (!valid) return;
 
-  const mealToSave = JSON.parse(JSON.stringify(editedItem.value));
-  (mealToSave.components || []).forEach(c => delete c.expanded);
+  isSubmitting.value = true;
+  const payload = prepareMealForSave(editedItem.value);
 
-
-  if (editedIndex.value > -1) {
-    meals.value[editedIndex.value] = mealToSave;
-  } else {
-    meals.value.unshift(mealToSave);
+  try {
+    if (editedIndex.value > -1) {
+      await dataStore.updateMealTemplate(payload.id, payload);
+    } else {
+      await dataStore.createMealTemplate(payload);
+    }
+    closeDialog();
+  } catch (error) {
+    isSubmitting.value = false;
+    // Keep the dialog open for corrections; error message shown via lastError
   }
-  closeDialog();
 }
 
-function deleteMeal(item) {
-  const index = meals.value.findIndex(m => m.id === item.id);
-  if (confirm('Are you sure you want to delete this meal?')) {
-    if (index > -1) meals.value.splice(index, 1);
+async function deleteMeal(item) {
+  if (!item?.id) return;
+  if (!confirm("Are you sure you want to delete this meal?")) return;
+  try {
+    await dataStore.deleteMealTemplate(item.id);
+  } catch (error) {
+    // Error surfaced via lastError
   }
 }
 </script>

--- a/src/views/PlanSummaryView.vue
+++ b/src/views/PlanSummaryView.vue
@@ -380,6 +380,17 @@ const emailSubject = ref("");
 const emailBody = ref("");
 
 onMounted(async () => {
+  try {
+    const loaders = [];
+    if (!foods.value.length) loaders.push(dataStore.fetchFoods().catch(() => {}));
+    if (!meals.value.length) loaders.push(dataStore.fetchMeals().catch(() => {}));
+    if (!recipes.value.length) loaders.push(dataStore.fetchRecipes().catch(() => {}));
+    if (loaders.length) {
+      await Promise.all(loaders);
+    }
+  } catch (error) {
+    // Errors are handled by the shared store state
+  }
   program.value = await dataStore.getProgramByClientId(clientId.value);
   isLoading.value = false;
   // Prefill email fields once client/program available

--- a/src/views/RecipesView.vue
+++ b/src/views/RecipesView.vue
@@ -197,10 +197,19 @@ const formTitle = computed(() =>
 const rules = { required: (value) => !!value || "Required." };
 
 onMounted(async () => {
-  if (!foods.value.length) {
-    await dataStore.fetchFoods().catch(() => {});
+  try {
+    const loaders = [];
+    if (!foods.value.length) {
+      loaders.push(dataStore.fetchFoods().catch(() => {}));
+    }
+    if (!meals.value.length) {
+      loaders.push(dataStore.fetchMeals().catch(() => {}));
+    }
+    loaders.push(dataStore.fetchRecipes().catch(() => {}));
+    await Promise.all(loaders);
+  } catch (error) {
+    // Errors surface through lastError already
   }
-  await dataStore.fetchRecipes().catch(() => {});
 });
 
 // --- HELPER FUNCTIONS ---


### PR DESCRIPTION
## Summary
- add a reset helper to the data store to clear cached entities and loading flags
- clear the shared data store whenever a user session changes so each account only sees its own data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6923400a4832ea0a380688e4099c4