### PR TITLE
Add start entry point for Render deployment

### DIFF
--- a/nutriz-backend/start.js
+++ b/nutriz-backend/start.js
@@ -1,0 +1,1 @@
+require('./server');


### PR DESCRIPTION
## Summary
- add a lightweight `start.js` entry point so hosts invoking `node start` boot the existing Express server

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68f85960f6a8832e83f3a01fe7cbb895