### PR TITLE
Normalize API base URL to include /api suffix

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,13 @@
 import axios from 'axios';
 
+const baseApiUrl = import.meta.env.VITE_API_URL || 'http://localhost:5000/api';
+
+const normalizedBaseUrl = baseApiUrl.endsWith('/api')
+  ? baseApiUrl
+  : `${baseApiUrl.replace(/\/$/, '')}/api`;
+
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api',
+  baseURL: normalizedBaseUrl,
 });
 
 export const setAuthToken = (token) => {


### PR DESCRIPTION
## Summary
- ensure the Axios client always targets the /api path even if VITE_API_URL omits it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f855c802b0832e9941fdac6f6d80ad