### PR TITLE
Fix axios base URL normalization to keep /api prefix

### DIFF
--- a/src/services/api.js
+++ b/src/services/api.js
@@ -6,8 +6,12 @@ const normalizedBaseUrl = baseApiUrl.endsWith('/api')
   ? baseApiUrl
   : `${baseApiUrl.replace(/\/$/, '')}/api`;
 
+const baseUrlWithTrailingSlash = normalizedBaseUrl.endsWith('/')
+  ? normalizedBaseUrl
+  : `${normalizedBaseUrl}/`;
+
 const api = axios.create({
-  baseURL: normalizedBaseUrl,
+  baseURL: baseUrlWithTrailingSlash,
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- ensure the client axios base URL always preserves the `/api` prefix by adding a trailing slash when needed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f86720ce60832ea951addd39881523